### PR TITLE
Fix query param ref array coercion

### DIFF
--- a/src/compileOperation.ts
+++ b/src/compileOperation.ts
@@ -143,7 +143,15 @@ export function compileOperation(
 
             const schemaFn = compileValueSchema(compiler, parameter.schema);
 
-            const isArrayType = 'type' in parameter.schema && parameter.schema.type === 'array';
+            let resolvedSchema = parameter.schema;
+            while (
+                typeof resolvedSchema === 'object' &&
+                resolvedSchema !== null &&
+                '$ref' in resolvedSchema
+            ) {
+                resolvedSchema = compiler.resolveRef(resolvedSchema);
+            }
+            const isArrayType = 'type' in resolvedSchema && resolvedSchema.type === 'array';
 
             // Assign the query parameter to a variable
             nodes.push(

--- a/src/tests/queryParameterCoercion.test.ts
+++ b/src/tests/queryParameterCoercion.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from 'bun:test';
+import { Compiler } from '../compiler';
+import type { OpenAPISpec } from '../types';
+
+type ValidateRequest = (request: {
+    method: string;
+    path: string;
+    query: Record<string, string | string[]>;
+    headers: Record<string, string>;
+    body?: unknown;
+}) => {
+    operationId?: string;
+    query: Record<string, unknown>;
+};
+
+function buildSpec(): OpenAPISpec {
+    return {
+        paths: {
+            '/inline-array': {
+                get: {
+                    operationId: 'inlineArray',
+                    parameters: [
+                        {
+                            name: 'addons',
+                            in: 'query',
+                            schema: {
+                                type: 'array',
+                                items: {
+                                    type: 'string',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            '/ref-array': {
+                get: {
+                    operationId: 'refArray',
+                    parameters: [
+                        {
+                            name: 'addons',
+                            in: 'query',
+                            schema: {
+                                $ref: '#/components/schemas/AddonsQuery',
+                            },
+                        },
+                    ],
+                },
+            },
+            '/non-array': {
+                get: {
+                    operationId: 'nonArray',
+                    parameters: [
+                        {
+                            name: 'addons',
+                            in: 'query',
+                            schema: {
+                                type: 'string',
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+        components: {
+            schemas: {
+                AddonsQuery: {
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                    },
+                },
+            },
+        },
+    };
+}
+
+function compileValidator(spec: OpenAPISpec) {
+    const code = new Compiler(spec).compile();
+    const runtimeCode = code.replace(/^export /gm, '');
+    const factory = new Function(`${runtimeCode}\nreturn { validateRequest };`) as () => {
+        validateRequest: ValidateRequest;
+    };
+
+    return {
+        code,
+        validateRequest: factory().validateRequest,
+    };
+}
+
+test('query string is coerced to array for inline array schema', () => {
+    const { validateRequest } = compileValidator(buildSpec());
+    const result = validateRequest({
+        path: '/inline-array',
+        method: 'get',
+        headers: {},
+        query: {
+            addons: 'translation_words',
+        },
+    });
+
+    expect(result.query).toEqual({ addons: ['translation_words'] });
+});
+
+test('query string is coerced to array for $ref array schema', () => {
+    const { validateRequest } = compileValidator(buildSpec());
+    const result = validateRequest({
+        path: '/ref-array',
+        method: 'get',
+        headers: {},
+        query: {
+            addons: 'translation_words',
+        },
+    });
+
+    expect(result.query).toEqual({ addons: ['translation_words'] });
+});
+
+test('query string is not coerced for non-array schema', () => {
+    const { validateRequest } = compileValidator(buildSpec());
+    const result = validateRequest({
+        path: '/non-array',
+        method: 'get',
+        headers: {},
+        query: {
+            addons: 'translation_words',
+        },
+    });
+
+    expect(result.query).toEqual({ addons: 'translation_words' });
+});
+
+test('compiled validator includes coercion for inline and $ref array schemas only', () => {
+    const { code } = compileValidator(buildSpec());
+    const coercionMatches = code.match(/queryParam0 = \[queryParam0\];/g) ?? [];
+
+    expect(code).toContain("if (typeof queryParam0 === 'string')");
+    expect(coercionMatches).toHaveLength(2);
+});


### PR DESCRIPTION
Fixes query param array coercion when the schema is a `$ref`.

We only coerced `string -> [string]` when `parameter.schema.type === 'array'` was defined inline in the spec. If the schema used a $ref pointing to an array schema, coercion was skipped and validation failed with a "expected an array" error.

For example, this query 

`GET /endpoint?parameter=value` 

would work for this schema:

`endpoint.yaml`
```yaml
  /content:
    get:
      parameters:
        - name: parameter
          in: query
          schema:
            type: array
            items:
              type: string
```

But fail for this schema:

`Parameter.yaml`
```yaml 
type: array
items:
  type: string
```

`endpoint.yaml`
```yaml
  /content:
    get:
      parameters:
        - name: parameter
          in: query
          schema:
            $ref: "./Parameter.yaml"
```
